### PR TITLE
Resolve makes a new object instead of return the setted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
         "psr-4": {
             "Php\\Container\\": "src/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
     }
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -48,6 +48,9 @@ class Container implements ContainerInterface
                 if (is_callable($name)) {
                     return $name();
                 }
+                if( is_object($name)){
+                    return $name;
+                }
             }
             return (new ReflectionClass($name));
         } catch (ReflectionException $e) {

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Php\Container\Container;
+
+class ContainerTest extends TestCase
+{
+    /** @test */
+    public function resolve_the_same_object_setted()
+    {
+        $expected = new \StdClass();
+    
+        $container = new Container;
+        $container->set('stdclass', $expected);
+        
+        $actual = $container->get('stdclass');
+        
+        $this->assertSame($expected, $actual);        
+    }
+}


### PR DESCRIPTION
As you can see running test (25017b0), if you set an object, resolve will make a new object instead of return the setted.
It can be fixed, asking if is_object($name) it's already an object.